### PR TITLE
Feature/view support

### DIFF
--- a/tap_oracle/sync_strategies/full_table.py
+++ b/tap_oracle/sync_strategies/full_table.py
@@ -91,6 +91,7 @@ def sync_table(connection, stream, state, desired_columns):
       singer.write_message(activate_version_message)
 
    with metrics.record_counter(None) as counter:
+      LOGGER.info("select %s", select_sql)
       for row in cur.execute(select_sql):
          record_message = row_to_singer_message(stream, row, nascent_stream_version, desired_columns, time_extracted)
          singer.write_message(record_message)


### PR DESCRIPTION
Support for replication views via full-table only.  Log Based replication would require discovering the underlying tables that constitute the view and then assembling the views fields from those tables.  A much simpler solution would just be to use LogMiner to replicate the underlying tables directly and then redefine the view query on the destination itself.