### PR TITLE
Fix/revert logminer committed data only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-oracle',
-      version='0.0.20',
+      version='0.0.19',
       description='Singer.io tap for extracting data from Oracle',
       author='Stitch',
       url='https://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-oracle',
-      version='0.0.21',
+      version='0.0.20',
       description='Singer.io tap for extracting data from Oracle',
       author='Stitch',
       url='https://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-oracle',
-      version='0.0.19',
+      version='0.0.21',
       description='Singer.io tap for extracting data from Oracle',
       author='Stitch',
       url='https://singer.io',

--- a/tap_oracle/sync_strategies/log_miner.py
+++ b/tap_oracle/sync_strategies/log_miner.py
@@ -146,7 +146,7 @@ def sync_tables(conn_config, streams, state):
       with metrics.record_counter(None) as counter:
          LOGGER.info("Examing log for table %s", stream.tap_stream_id)
          common.send_schema_message(stream, ['lsn'])
-         for op, redo, scn, ts, cscn, commit_ts, *col_vals in cur.execute(mine_sql, binds):
+         for op, redo, scn, timestamp, cscn, commit_ts, *col_vals in cur.execute(mine_sql, binds):
             redo_vals = col_vals[0:len(desired_columns)]
             undo_vals = col_vals[len(desired_columns):]
             if op == 'INSERT' or op == 'UPDATE':

--- a/tap_oracle/sync_strategies/log_miner.py
+++ b/tap_oracle/sync_strategies/log_miner.py
@@ -108,13 +108,12 @@ def sync_tables(conn_config, streams, state):
    end_scn = fetch_current_scn(conn_config)
    time_extracted = utils.now()
 
-   # NB: Removed DBMS_LOGMNR.COMMITTED_DATA_ONLY from OPTIONS to evaluate effect on memory consumption and data integrity.
-   #     Ideally, this should be configurable, or we can buffer transactions in memory and when we find a commit, then emit the records
    start_logmnr_sql = """BEGIN
                          DBMS_LOGMNR.START_LOGMNR(
                                  startScn => {},
                                  endScn => {},
                                  OPTIONS => DBMS_LOGMNR.DICT_FROM_ONLINE_CATALOG +
+                                            DBMS_LOGMNR.COMMITTED_DATA_ONLY +
                                             DBMS_LOGMNR.CONTINUOUS_MINE);
                          END;""".format(start_scn, end_scn)
 

--- a/tap_oracle/sync_strategies/log_miner.py
+++ b/tap_oracle/sync_strategies/log_miner.py
@@ -134,7 +134,7 @@ def sync_tables(conn_config, streams, state):
       schema_name = md_map.get(()).get('schema-name')
       stream_version = get_stream_version(stream.tap_stream_id, state)
       mine_sql = """
-      SELECT OPERATION, SQL_REDO, SCN, TIMESTAMP, CSCN, COMMIT_TIMESTAMP,  {}, {} from v$logmnr_contents where table_name = :table_name AND operation in ('INSERT', 'UPDATE', 'DELETE')
+      SELECT OPERATION, SQL_REDO, SCN, CSCN, COMMIT_TIMESTAMP,  {}, {} from v$logmnr_contents where table_name = :table_name AND operation in ('INSERT', 'UPDATE', 'DELETE')
       """.format(redo_value_sql_clause, undo_value_sql_clause)
       binds = [orc_db.fully_qualified_column_name(schema_name, stream.table, c) for c in desired_columns] + \
               [orc_db.fully_qualified_column_name(schema_name, stream.table, c) for c in desired_columns] + \
@@ -146,14 +146,14 @@ def sync_tables(conn_config, streams, state):
       with metrics.record_counter(None) as counter:
          LOGGER.info("Examing log for table %s", stream.tap_stream_id)
          common.send_schema_message(stream, ['lsn'])
-         for op, redo, scn, timestamp, cscn, commit_ts, *col_vals in cur.execute(mine_sql, binds):
+         for op, redo, scn, cscn, commit_ts, *col_vals in cur.execute(mine_sql, binds):
             redo_vals = col_vals[0:len(desired_columns)]
             undo_vals = col_vals[len(desired_columns):]
             if op == 'INSERT' or op == 'UPDATE':
-               redo_vals += [scn, None]
+               redo_vals += [cscn, None]
                record_message = row_to_singer_message(stream, redo_vals, stream_version, columns_for_record, time_extracted)
             elif op == 'DELETE':
-               undo_vals += [scn, singer.utils.strftime(ts.replace(tzinfo=pytz.UTC))]
+               undo_vals += [cscn, singer.utils.strftime(commit_ts.replace(tzinfo=pytz.UTC))]
                record_message = row_to_singer_message(stream, undo_vals, stream_version, columns_for_record, time_extracted)
             else:
                raise Exception("unrecognized logminer operation: {}".format(op))
@@ -164,7 +164,7 @@ def sync_tables(conn_config, streams, state):
             state = singer.write_bookmark(state,
                                           stream.tap_stream_id,
                                           'scn',
-                                          int(scn))
+                                          int(cscn))
 
 
             if rows_saved % UPDATE_BOOKMARK_PERIOD == 0:


### PR DESCRIPTION
TLDR - `COMMITTED_DATA_ONLY` must be set for data integrity, this PR reverts back to that state.

Removing this setting revealed a flaw that is unclear how the tap would handle it. Without the `COMMITTED_DATA_ONLY` option set on the logminer, rolled back transactions get records in the log, and also their inverse records. For example:

Update DML:
```
INFO ['1.27.4063', 'UPDATE', 'update "ROOT"."CHICKEN" set "NAME" = \'apples\' where "ID" = \'5\' and "NAME" = \'ROLLEDBACK\' and "CASH" = \'1223345\' and ROWID = \'AAAM2dAAAAAABTLAAA\';', 13285089, datetime.datetime(2018, 7, 24, 15, 15, 15), '1223345', 'apples', '5', '1223345', 'ROLLEDBACK', '5']
```

Rolled-back inverse operation:
```
INFO ['1.27.4063', 'UPDATE', 'update "ROOT"."CHICKEN" set "NAME" = \'ROLLEDBACK\' where ROWID = \'AAAM2dAAAAAABTLAAA\';', 13285092, datetime.datetime(2018, 7, 24, 15, 15, 15), '1223345', 'ROLLEDBACK', '5', '1223345', None, '5']
```

However, when the statement in the transaction is an `INSERT` the inverse operation is a `DELETE` which has row values equal to `Null, Null, Null` for `id, name, cash` in the example above. The delete statement references the specific `ROW_ID` that was deleted, but without any guarantees that `ROW_ID` is consistent for any period of time, there's no solid way to map this entry to the row that was previously inserted before the transaction rolled back. The Singer record generated results in a Schema violation error, since we don't have the PK that the delete record references.