### PR TITLE
use windowing for scn

### DIFF
--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -544,7 +544,7 @@ def main_impl():
                   'sid':  args.config['sid']}
 
    if args.config.get('scn_window_size'):
-      log_miner.SCN_WINDOW_SIZE=args.config['scn_window_size']
+      log_miner.SCN_WINDOW_SIZE=int(args.config['scn_window_size'])
    if args.discover:
       filter_schemas_prop = args.config.get('filter_schemas')
       filter_schemas = []

--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -543,7 +543,8 @@ def main_impl():
                   'port': args.config['port'],
                   'sid':  args.config['sid']}
 
-
+   if args.config.get('scn_window_size'):
+      log_miner.SCN_WINDOW_SIZE=args.config['scn_window_size']
    if args.discover:
       filter_schemas_prop = args.config.get('filter_schemas')
       filter_schemas = []


### PR DESCRIPTION
Use an optional parameter (`scn_window_size`) to allow the tap to window the requested scn's during log-based sync. This is to prevent the tap from timing out when requesting a large range of scn's.  