### PR TITLE
Version 1.0.0 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.0
+ * Backwards incompatible change to the way that data types are discovered and parsed [#22](https://github.com/singer-io/tap-oracle/pull/22)
+   * Oracle numeric types with a null scale (`NUMBER` and `NUMBER(*)`) will now be correctly discovered as floating point types rather than integers.
+   * This may cause downstream issues with loading and reporting, so a major bump is required.
+
 ## 0.3.1
  * Adds handling for columns that do not have a datatype -- those columns will have `inclusion`=`unavailable` and `sql-datatype`=`"None"` [#19](https://github.com/singer-io/tap-oracle/pull/19)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-oracle',
-      version='0.3.1',
+      version='1.0.0',
       description='Singer.io tap for extracting data from Oracle',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
Version bump to 1.0.0 for #22 

# Manual QA steps
 - N/A just a version bump and MD file
 
# Risks
 - Low, data typing issues are accounted for in the major version designation
 
# Rollback steps
 - revert #22 and release new version (major or patch, depending on the situation for revert)
