### PR TITLE
Bump default numeric scale from 6 to 38

### DIFF
--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -64,7 +64,7 @@ DEFAULT_NUMERIC_PRECISION=38
 # Experimentally, we observed 6 digits to the right of the decimal place
 # as maximum scale stored when not specified (e.g., NUMERIC(*) or NUMERIC
 # types)
-DEFAULT_NUMERIC_SCALE=6
+DEFAULT_NUMERIC_SCALE=38
 
 def nullable_column(col_name, col_type, pks_for_table):
    if col_name in pks_for_table:

--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -61,9 +61,9 @@ REQUIRED_CONFIG_KEYS = [
 
 DEFAULT_NUMERIC_PRECISION=38
 
-# Experimentally, we observed 6 digits to the right of the decimal place
-# as maximum scale stored when not specified (e.g., NUMERIC(*) or NUMERIC
-# types)
+# Default scale seems to vary by Oracle version. We've observed 12c
+# returning 6 digits and 11g returning 14 places. Setting max at 38 to
+# align with the Singer libraries' maximum.
 DEFAULT_NUMERIC_SCALE=38
 
 def nullable_column(col_name, col_type, pks_for_table):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -161,7 +161,7 @@ class TestDecimalPK(unittest.TestCase):
             self.assertEqual(len(chicken_streams), 1)
             stream_dict = chicken_streams[0].to_dict()
             stream_dict.get('metadata').sort(key=lambda md: md['breadcrumb'])
-            self.assertEqual({'schema': {'properties': {'our_number': {'multipleOf': 1e-06,
+            self.assertEqual({'schema': {'properties': {'our_number': {'multipleOf': 1e-38,
                                                                        'type': ['number']},
                                                         'our_number_10_2': {'multipleOf': 0.01,
                                                                             'type': ['null', 'number']},


### PR DESCRIPTION
# Description of change
This PR bumps the default numeric scale because we saw a sync job that was returning a number with more 6 digits, but the schema message had a `multipleOf` of just 6.

# Manual QA steps
 - Ran the tests locally
 
# Risks
 - Low, having more scale here can't hurt
 
# Rollback steps
 - revert this branch
