### PR TITLE
Use custom formatter for decimal types

### DIFF
--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -84,10 +84,10 @@ def schema_for_column(c, pks_for_table):
 
    elif data_type == 'number':
       # NB: Due to scale and precision variations in Oracle version, and
-      #     among numeric types, we're using a custom `decimal` string
+      #     among numeric types, we're using a custom `singer.decimal` string
       #     formatter for this, with no opinion on scale/precision.
       result.type = nullable_column(c.column_name, 'string', pks_for_table)
-      result.format = 'decimal'
+      result.format = 'singer.decimal'
 
       return result
 
@@ -116,7 +116,7 @@ def schema_for_column(c, pks_for_table):
    #"float", "double_precision", "real"
    elif data_type in ['float', 'double_precision']:
       result.type = nullable_column(c.column_name, 'string', pks_for_table)
-      result.format = 'decimal'
+      result.format = 'singer.decimal'
       return result
 
    return Schema(None)

--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -59,8 +59,6 @@ REQUIRED_CONFIG_KEYS = [
     'password'
 ]
 
-DEFAULT_NUMERIC_PRECISION=38
-
 def nullable_column(col_name, col_type, pks_for_table):
    if col_name in pks_for_table:
       return  [col_type]
@@ -78,8 +76,6 @@ def schema_for_column(c, pks_for_table):
 
    # Scale of None indicates default of 6 digits
    numeric_scale = c.numeric_scale
-   # Precision is always non-zero and defaults to 38 digits
-   numeric_precision = c.numeric_precision or DEFAULT_NUMERIC_PRECISION
 
    if data_type == 'number' and numeric_scale is not None and numeric_scale <= 0:
       result.type = nullable_column(c.column_name, 'integer', pks_for_table)

--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -84,8 +84,6 @@ def schema_for_column(c, pks_for_table):
    if data_type == 'number' and numeric_scale is not None and numeric_scale <= 0:
       result.type = nullable_column(c.column_name, 'integer', pks_for_table)
 
-      if numeric_scale < 0:
-         result.multipleOf = -10 * numeric_scale
       return result
 
    elif data_type == 'number':

--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -81,7 +81,7 @@ def schema_for_column(c, pks_for_table):
    # Precision is always non-zero and defaults to 38 digits
    numeric_precision = c.numeric_precision or DEFAULT_NUMERIC_PRECISION
 
-   if data_type == 'number' and numeric_scale <= 0:
+   if data_type == 'number' and numeric_scale is not None and numeric_scale <= 0:
       result.type = nullable_column(c.column_name, 'integer', pks_for_table)
 
       if numeric_scale < 0:

--- a/tap_oracle/sync_strategies/common.py
+++ b/tap_oracle/sync_strategies/common.py
@@ -33,7 +33,7 @@ def row_to_singer_message(stream, row, version, columns, time_extracted):
         property_format = stream.schema.properties[columns[idx]].format
         if elem is None:
             row_to_persist += (elem,)
-        elif ('string' in property_type or property_type == 'string') and property_format == 'decimal':
+        elif ('string' in property_type or property_type == 'string') and property_format == 'singer.decimal':
             row_to_persist += (str(elem),)
         elif 'integer' in property_type or property_type == 'integer':
             integer_representation = int(elem)

--- a/tap_oracle/sync_strategies/common.py
+++ b/tap_oracle/sync_strategies/common.py
@@ -27,28 +27,31 @@ def send_schema_message(stream, bookmark_properties):
     singer.write_message(schema_message)
 
 def row_to_singer_message(stream, row, version, columns, time_extracted):
-   row_to_persist = ()
-   for idx, elem in enumerate(row):
-      property_type = stream.schema.properties[columns[idx]].type
-      if elem is None:
-         row_to_persist += (elem,)
-      elif 'integer' in property_type or property_type == 'integer':
-         integer_representation = int(elem)
-         row_to_persist += (integer_representation,)
-      else:
-         row_to_persist += (elem,)
+    row_to_persist = ()
+    for idx, elem in enumerate(row):
+        property_type = stream.schema.properties[columns[idx]].type
+        property_format = stream.schema.properties[columns[idx]].format
+        if elem is None:
+            row_to_persist += (elem,)
+        elif ('string' in property_type or property_type == 'string') and property_format == 'decimal':
+            row_to_persist += (str(elem),)
+        elif 'integer' in property_type or property_type == 'integer':
+            integer_representation = int(elem)
+            row_to_persist += (integer_representation,)
+        else:
+            row_to_persist += (elem,)
 
-   rec = dict(zip(columns, row_to_persist))
+    rec = dict(zip(columns, row_to_persist))
 
-   return singer.RecordMessage(
-      stream=stream.stream,
-      record=rec,
-      version=version,
-      time_extracted=time_extracted)
+    return singer.RecordMessage(
+        stream=stream.stream,
+        record=rec,
+        version=version,
+        time_extracted=time_extracted)
 
 def OutputTypeHandler(cursor, name, defaultType, size, precision, scale):
-   if defaultType == cx_Oracle.NUMBER:
-      return cursor.var(decimal.Decimal, arraysize = cursor.arraysize)
+    if defaultType == cx_Oracle.NUMBER:
+        return cursor.var(decimal.Decimal, arraysize = cursor.arraysize)
 
 
 def prepare_columns_sql(stream, c):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -160,11 +160,11 @@ class TestDecimalPK(unittest.TestCase):
             self.assertEqual(len(chicken_streams), 1)
             stream_dict = chicken_streams[0].to_dict()
             stream_dict.get('metadata').sort(key=lambda md: md['breadcrumb'])
-            self.assertEqual({'schema': {'properties': {'our_number': {'format': 'decimal',
+            self.assertEqual({'schema': {'properties': {'our_number': {'format': 'singer.decimal',
                                                                        'type': ['string']},
-                                                        'our_number_10_2': {'format': 'decimal',
+                                                        'our_number_10_2': {'format': 'singer.decimal',
                                                                             'type': ['null', 'string']},
-                                                        'our_number_38_4': {'format': 'decimal',
+                                                        'our_number_38_4': {'format': 'singer.decimal',
                                                                             'type': ['null', 'string']}},
                                          'type': 'object'},
                               'stream': 'CHICKEN',
@@ -251,11 +251,11 @@ class TestFloatTablePK(unittest.TestCase):
 
             stream_dict.get('metadata').sort(key=lambda md: md['breadcrumb'])
             self.assertEqual({'schema': {'properties': {'our_float':               {'type': ['string'],
-                                                                                    'format': 'decimal'},
+                                                                                    'format': 'singer.decimal'},
                                                         'our_double_precision':    {'type': ['null', 'string'],
-                                                                                    'format': 'decimal'},
+                                                                                    'format': 'singer.decimal'},
                                                         'our_real':                {'type': ['null', 'string'],
-                                                                                    'format': 'decimal'},
+                                                                                    'format': 'singer.decimal'},
                                                         'our_binary_float':        {'type': ['null', 'number']},
                                                         'our_binary_double':       {'type': ['null', 'number']}},
                                          'type': 'object'},

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -109,8 +109,7 @@ class TestIntegerTablePK(unittest.TestCase):
 
             stream_dict.get('metadata').sort(key=lambda md: md['breadcrumb'])
 
-            self.assertEqual({'schema': {'properties': {'size_number_10_-1':    {'multipleOf': 10,
-                                                                                 'type': ['null', 'integer']},
+            self.assertEqual({'schema': {'properties': {'size_number_10_-1':    {'type': ['null', 'integer']},
                                                         'size_number_*_0':      {'type': ['null', 'integer']},
                                                         'size_number_integer':  {'type': ['null', 'integer']},
                                                         'size_number_4':      {'type': ['null', 'integer']},
@@ -161,12 +160,12 @@ class TestDecimalPK(unittest.TestCase):
             self.assertEqual(len(chicken_streams), 1)
             stream_dict = chicken_streams[0].to_dict()
             stream_dict.get('metadata').sort(key=lambda md: md['breadcrumb'])
-            self.assertEqual({'schema': {'properties': {'our_number': {'multipleOf': 1e-38,
-                                                                       'type': ['number']},
-                                                        'our_number_10_2': {'multipleOf': 0.01,
-                                                                            'type': ['null', 'number']},
-                                                        'our_number_38_4': {'multipleOf': 0.0001,
-                                                                            'type': ['null', 'number']}},
+            self.assertEqual({'schema': {'properties': {'our_number': {'format': 'decimal',
+                                                                       'type': ['string']},
+                                                        'our_number_10_2': {'format': 'decimal',
+                                                                            'type': ['null', 'string']},
+                                                        'our_number_38_4': {'format': 'decimal',
+                                                                            'type': ['null', 'string']}},
                                          'type': 'object'},
                               'stream': 'CHICKEN',
                               'table_name': 'CHICKEN',
@@ -251,12 +250,12 @@ class TestFloatTablePK(unittest.TestCase):
             stream_dict = chicken_streams[0].to_dict()
 
             stream_dict.get('metadata').sort(key=lambda md: md['breadcrumb'])
-            self.assertEqual({'schema': {'properties': {'our_float':               {'type': ['number'],
-                                                                                    'multipleOf': 1e-38},
-                                                        'our_double_precision':    {'type': ['null', 'number'],
-                                                                                    'multipleOf': 1e-38},
-                                                        'our_real':                {'type': ['null', 'number'],
-                                                                                    'multipleOf': 1e-18},
+            self.assertEqual({'schema': {'properties': {'our_float':               {'type': ['string'],
+                                                                                    'format': 'decimal'},
+                                                        'our_double_precision':    {'type': ['null', 'string'],
+                                                                                    'format': 'decimal'},
+                                                        'our_real':                {'type': ['null', 'string'],
+                                                                                    'format': 'decimal'},
                                                         'our_binary_float':        {'type': ['null', 'number']},
                                                         'our_binary_double':       {'type': ['null', 'number']}},
                                          'type': 'object'},

--- a/tests/test_full_table.py
+++ b/tests/test_full_table.py
@@ -199,23 +199,23 @@ class FullTable(unittest.TestCase):
 
             expected_rec_1 = {'ID'                  : 1,
                               'none_column'         : None,
-                              'size_number'         : decimal.Decimal('0.000001'),
-                              'size_number_*'       : decimal.Decimal('100.12345'),
+                              'size_number'         : '0.000001',
+                              'size_number_*'       : '100.12345',
                               'size_number_4'       : 100,
                               'size_number_4_0'     : 100,
                               'size_number_*_0'     : 2 ** 128,
-                              'size_number_*_38'    : decimal.Decimal('0.000001'),
+                              'size_number_*_38'    : '0.000001',
                               'size_number_10_-1'   : 310,
                               'size_number_integer' : 400,
                               'size_number_int'     : 500,
                               'size_number_smallint': 50000,
 
-                              'our_number_10_2'     : decimal.Decimal('100.11'),
-                              'our_number_38_4'     : decimal.Decimal('99999999999999999.9999'),
+                              'our_number_10_2'     : '100.11',
+                              'our_number_38_4'     : '99999999999999999.9999',
 
-                              'our_double_precision': decimal.Decimal('1234567.8901234567890123456789012345679'),
-                              'our_float'           : decimal.Decimal('1234567.8901234567890123456789012345679'),
-                              'our_real'            : decimal.Decimal('1234567.890123456789'),
+                              'our_double_precision': '1234567.8901234567890123456789012345679',
+                              'our_float'           : '1234567.8901234567890123456789012345679',
+                              'our_real'            : '1234567.890123456789',
 
 
 
@@ -247,10 +247,10 @@ class FullTable(unittest.TestCase):
 
             expected_rec_2 = expected_rec_1
             expected_rec_2.update({
-                'ID': decimal.Decimal(2),
-                'size_number_4_0' : decimal.Decimal('101'),
-                'our_number_10_2' : decimal.Decimal('101.11') + 1,
-                'our_double_precision' : our_double_precision + 1,
+                'ID': 2,
+                'size_number_4_0' : 101,
+                'our_number_10_2' : '102.11',
+                'our_double_precision' : '1234568.890123456789012345679',
                 'our_date' : '1996-06-07T00:00:00.00+00:00',
                 'NAME_NCHAR' :  'name-nchar II                                                                                                              '})
             self.assertTrue(math.isnan(CAUGHT_MESSAGES[4].record.get('our_nan')))

--- a/tests/test_log_miner_decimals.py
+++ b/tests/test_log_miner_decimals.py
@@ -97,14 +97,14 @@ class MineDecimals(unittest.TestCase):
             insert_rec_1 = CAUGHT_MESSAGES[1].record
             self.assertIsNotNone(insert_rec_1.get('scn'))
             insert_rec_1.pop('scn')
-            self.assertEqual(insert_rec_1, {'our_number_38_4': decimal.Decimal('99999999999999999.9999'), 'our_number': 1, 'our_number_10_2': decimal.Decimal('100.11'), '_sdc_deleted_at': None})
+            self.assertEqual(insert_rec_1, {'our_number_38_4': '99999999999999999.9999', 'our_number': '1', 'our_number_10_2': '100.11', '_sdc_deleted_at': None})
 
 
             #verify UPDATE
             update_rec = CAUGHT_MESSAGES[5].record
             self.assertIsNotNone(update_rec.get('scn'))
             update_rec.pop('scn')
-            self.assertEqual(update_rec, {'our_number_38_4': decimal.Decimal('100000000000000004.9999'), 'our_number': 1, 'our_number_10_2': decimal.Decimal('105.11'), '_sdc_deleted_at': None})
+            self.assertEqual(update_rec, {'our_number_38_4': '100000000000000004.9999', 'our_number': '1', 'our_number_10_2': '105.11', '_sdc_deleted_at': None})
 
             #verify first DELETE message
             delete_rec = CAUGHT_MESSAGES[9].record
@@ -113,9 +113,9 @@ class MineDecimals(unittest.TestCase):
             delete_rec.pop('scn')
             delete_rec.pop('_sdc_deleted_at')
             self.assertEqual(delete_rec,
-                             {'our_number_38_4': decimal.Decimal('100000000000000004.9999'),
-                              'our_number': 1,
-                              'our_number_10_2': decimal.Decimal('105.11')})
+                             {'our_number_38_4': '100000000000000004.9999',
+                              'our_number': '1',
+                              'our_number_10_2': '105.11'})
 
 
             #verify second DELETE message
@@ -125,9 +125,9 @@ class MineDecimals(unittest.TestCase):
             delete_rec_2.pop('scn')
             delete_rec_2.pop('_sdc_deleted_at')
             self.assertEqual(delete_rec_2,
-                             {'our_number_38_4': decimal.Decimal('100000000000000004.9999'),
-                              'our_number': 2,
-                              'our_number_10_2': decimal.Decimal('105.11')})
+                             {'our_number_38_4': '100000000000000004.9999',
+                              'our_number': '2',
+                              'our_number_10_2': '105.11'})
 
 
 

--- a/tests/test_log_miner_floats.py
+++ b/tests/test_log_miner_floats.py
@@ -121,10 +121,11 @@ class MineFloats(unittest.TestCase):
             self.assertTrue(math.isnan(insert_rec_1.get('our_nan')))
             insert_rec_1.pop('our_nan')
 
+
             self.assertEqual(insert_rec_1, {
-                                 'our_float': decimal.Decimal('1.0'),
-                                 'our_double_precision': our_fake_float,
-                                 'our_real': our_fake_float,
+                                 'our_float': '1',
+                                 'our_double_precision': str(our_fake_float),
+                                 'our_real': str(our_fake_float),
                                  'our_binary_float': 1234567.88, #weird
                                  'our_binary_double': 1234567.890123,
                                  '_sdc_deleted_at': None})
@@ -145,9 +146,9 @@ class MineFloats(unittest.TestCase):
             self.assertEqual(update_rec, {'our_binary_double': 1234572.890123,
                                           '_sdc_deleted_at': None,
                                           'our_binary_float': 1234572.88,
-                                          'our_float': decimal.Decimal('1'),
-                                          'our_double_precision': decimal.Decimal('1234572.8901234'),
-                                          'our_real': decimal.Decimal('1234572.8901234')})
+                                          'our_float': '1',
+                                          'our_double_precision': '1234572.8901234',
+                                          'our_real': '1234572.8901234'})
 
             #verify first DELETE message
             delete_rec = CAUGHT_MESSAGES[9].record
@@ -168,9 +169,9 @@ class MineFloats(unittest.TestCase):
             self.assertEqual(delete_rec,
                              {'our_binary_double': 1234572.890123,
                               'our_binary_float': 1234572.88,
-                              'our_float': decimal.Decimal('1'),
-                              'our_double_precision': decimal.Decimal('1234572.8901234'),
-                              'our_real': decimal.Decimal('1234572.8901234')})
+                              'our_float': '1',
+                              'our_double_precision': '1234572.8901234',
+                              'our_real': '1234572.8901234'})
 
             #verify second DELETE message
             delete_rec_2 = CAUGHT_MESSAGES[11].record
@@ -192,9 +193,9 @@ class MineFloats(unittest.TestCase):
             self.assertEqual(delete_rec_2,
                              {'our_binary_double': 1234572.890123,
                               'our_binary_float': 1234572.88,
-                              'our_float': decimal.Decimal('2'),
-                              'our_double_precision': decimal.Decimal('1234572.8901234'),
-                              'our_real': decimal.Decimal('1234572.8901234')})
+                              'our_float': '2',
+                              'our_double_precision': '1234572.8901234',
+                              'our_real': '1234572.8901234'})
 
 
 


### PR DESCRIPTION
# Description of change
Due to issues with identifying precision and scale values in certain conditions under varying Oracle DB versions, we've decided to test out a custom Singer-decimal kind of formatter that maintains all decimal precision.

That way the decision to truncate or reject values gets offloaded to the "Load" step in the pipeline.

# Manual QA steps
- This is a replacement of `multipleOf` functionality with `type: string, format: decimal`
- It should be caught by automation.
    - Confirming that the automation tests changed _only_ from a schema with `multipleOf` to a schema with `format: decimal` to maintain final typing with previous assumption
 
# Risks
 - Medium, this may cause unexpected rejection/truncation downstream, but that seems like the most appropriate behavior rather than the tap truncating.
 
# Rollback steps
 - revert this branch
