### PR TITLE
Get replication key inside loop for incremental limit

### DIFF
--- a/tap_oracle/sync_strategies/incremental.py
+++ b/tap_oracle/sync_strategies/incremental.py
@@ -60,11 +60,11 @@ def sync_table(conn_config, stream, state, desired_columns):
 
    replication_key = md.get((), {}).get('replication-key')
    #escaped_replication_key = common.prepare_columns_sql(stream, replication_key)
-   replication_key_value = singer.get_bookmark(state, stream.tap_stream_id, 'replication_key_value')
    replication_key_sql_datatype = md.get(('properties', replication_key)).get('sql-datatype')
 
    iterate_limit = True
    while iterate_limit:
+      replication_key_value = singer.get_bookmark(state, stream.tap_stream_id, 'replication_key_value')
       with metrics.record_counter(None) as counter:
          if replication_key_value:
             LOGGER.info("Resuming Incremental replication from %s = %s", replication_key, replication_key_value)


### PR DESCRIPTION
# Description of change
We were only getting the replication key once at the beginning of the stream sync. This led to the subsequent query with the limit to use the original state's `replication_key_value` instead of the latest value from the previous query.

This change moves the `replication_key_value` "get" inside the loop, so the value updates properly for the next query.

# Manual QA steps
 - Tested with cloned connection to verify queries use updated value.
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
